### PR TITLE
Enable immediate Renovate PR creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,10 @@
   "timezone": "Asia/Tokyo",
   "baseBranches": ["develop"],
   "dependencyDashboard": true,
+  "prCreation": "immediate",
   "labels": [],
-  "schedule": ["after 8am and before 9am every weekday"],
   "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["after 8am and before 9am on monday"]
+    "enabled": true
   },
   "packageRules": [
     {


### PR DESCRIPTION
Remove schedule restrictions so pending dependency updates can open PRs as soon as Renovate runs.

## Description

Enable immediate Renovate PR creation

## Related Issues

<!-- Link related issues below. -->

## Changes

- Update `renovate.json`

## Checklist

- [x] Code passes `pnpm check:all` (format, lint, typecheck, test)
- [x] Tested locally with `pnpm dev`
- [x] Changes are consistent with the existing codebase style
